### PR TITLE
migrations-source-config-fix: Changed name and tags on MigrationsSource

### DIFF
--- a/components/mongo/config.go
+++ b/components/mongo/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	TlsSkipVerifyHost bool `json:"tls_skip_verify_host" yaml:"tls_skip_verify_host"`
 
 	// MigrationSource indicates the source where migration scripts are located
-	MigrationSource string `json:"migration_source" yaml:"migration_source"`
+	MigrationsSource string `json:"migrations_source" yaml:"migrations_source"`
 }
 
 func (c *Config) opts() *options.ClientOptions {

--- a/components/mongo/migration.go
+++ b/components/mongo/migration.go
@@ -17,15 +17,16 @@ func MigrateMongo(cfg ...*Config) error {
 		c = getConfig()
 	}
 
-	if c == nil || c.MigrationSource == "" {
+	if c == nil || c.MigrationsSource == "" {
+		logx.Info("No MigrationsSource config, will not apply migrations")
 		return nil
 	}
-	migrator, err := migrate.New(c.MigrationSource, c.url())
+	migrator, err := migrate.New(c.MigrationsSource, c.url())
 	if err != nil {
 		return err
 	}
 
-	logx.Info(fmt.Sprintf("Applying migrations from source %s", c.MigrationSource))
+	logx.Info(fmt.Sprintf("Applying migrations from source %s", c.MigrationsSource))
 
 	migErr := migrator.Up()
 


### PR DESCRIPTION
config, added logging to prevent human error